### PR TITLE
fix(package version): Update contenta_vue_nuxt version into package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contenta_vue_nuxt",
-  "version": "0.5.0",
+  "version": "0.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
On package.json, contenta_vue_nuxt is at "version": "0.8.3".
On package-lock.json, contenta_vue_nuxt is at "version": "0.5.0"

After a "npm install", the package-lock.json is updated and the version is updated to "0.8.3" (tested with node v8.6.0 / npm 5.3.0).

The PR update the contenta_vue_nuxt version in package-lock.json.