### PR TITLE
Add a base images url option.

### DIFF
--- a/components/RecipeCard.vue
+++ b/components/RecipeCard.vue
@@ -3,7 +3,7 @@
     <BulmaCard>
       <div slot="image" v-if="recipe.image" class="">
         <figure class="image is-3by2">
-          <img class="lazy-img-fadein" v-lazy="`${serverImagesUrl}/${recipe.image.thumbnail.url}`" />
+          <img class="lazy-img-fadein" v-lazy="`${serverFilesUrl}/${recipe.image.thumbnail.url}`" />
         </figure>
       </div>
       <div slot="content" class="has-text-centered">
@@ -26,7 +26,7 @@ export default {
   },
   computed: {
     serverBaseUrl: () => process.env.serverBaseUrl,
-    serverImagesUrl: () => process.env.serverImagesUrl,
+    serverFilesUrl: () => process.env.serverFilesUrl,
   },
 };
 </script>

--- a/components/RecipeCard.vue
+++ b/components/RecipeCard.vue
@@ -3,7 +3,7 @@
     <BulmaCard>
       <div slot="image" v-if="recipe.image" class="">
         <figure class="image is-3by2">
-          <img class="lazy-img-fadein" v-lazy="`${serverBaseUrl}/${recipe.image.thumbnail.url}`" />
+          <img class="lazy-img-fadein" v-lazy="`${serverImagesUrl}/${recipe.image.thumbnail.url}`" />
         </figure>
       </div>
       <div slot="content" class="has-text-centered">
@@ -26,6 +26,7 @@ export default {
   },
   computed: {
     serverBaseUrl: () => process.env.serverBaseUrl,
+    serverImagesUrl: () => process.env.serverImagesUrl,
   },
 };
 </script>

--- a/components/RecipeDetail.vue
+++ b/components/RecipeDetail.vue
@@ -15,7 +15,7 @@
         <div class="columns">
           <div class="column">
             <figure class="image is-3by2">
-              <img v-lazy="`${serverBaseUrl}/${recipe.image.thumbnail.url}`" />
+              <img v-lazy="`${serverImagesUrl}/${recipe.image.thumbnail.url}`" />
             </figure>
           </div>
           <div class="column">
@@ -99,6 +99,7 @@ export default {
   },
   computed: {
     serverBaseUrl: () => process.env.serverBaseUrl,
+    serverImagesUrl: () => process.env.serverImagesUrl,
   },
 };
 </script>

--- a/components/RecipeDetail.vue
+++ b/components/RecipeDetail.vue
@@ -15,7 +15,7 @@
         <div class="columns">
           <div class="column">
             <figure class="image is-3by2">
-              <img v-lazy="`${serverImagesUrl}/${recipe.image.thumbnail.url}`" />
+              <img v-lazy="`${serverFilesUrl}/${recipe.image.thumbnail.url}`" />
             </figure>
           </div>
           <div class="column">
@@ -99,7 +99,7 @@ export default {
   },
   computed: {
     serverBaseUrl: () => process.env.serverBaseUrl,
-    serverImagesUrl: () => process.env.serverImagesUrl,
+    serverFilesUrl: () => process.env.serverFilesUrl,
   },
 };
 </script>

--- a/components/RecipePromotedBanner.vue
+++ b/components/RecipePromotedBanner.vue
@@ -12,7 +12,7 @@
           <div class="column">
             <nuxt-link :to="'/recipes/' + recipe.id">
               <figure class="image is-3by2">
-                <img v-if="recipe.image" v-lazy="`${serverBaseUrl}/${recipe.image.thumbnail.url}`" />
+                <img v-if="recipe.image" v-lazy="`${serverImagesUrl}/${recipe.image.thumbnail.url}`" />
               </figure>
             </nuxt-link>
           </div>
@@ -33,6 +33,7 @@ export default {
   },
   computed: {
     serverBaseUrl: () => process.env.serverBaseUrl,
+    serverImagesUrl: () => process.env.serverImagesUrl,
   },
 };
 </script>

--- a/components/RecipePromotedBanner.vue
+++ b/components/RecipePromotedBanner.vue
@@ -12,7 +12,7 @@
           <div class="column">
             <nuxt-link :to="'/recipes/' + recipe.id">
               <figure class="image is-3by2">
-                <img v-if="recipe.image" v-lazy="`${serverImagesUrl}/${recipe.image.thumbnail.url}`" />
+                <img v-if="recipe.image" v-lazy="`${serverFilesUrl}/${recipe.image.thumbnail.url}`" />
               </figure>
             </nuxt-link>
           </div>
@@ -33,7 +33,7 @@ export default {
   },
   computed: {
     serverBaseUrl: () => process.env.serverBaseUrl,
-    serverImagesUrl: () => process.env.serverImagesUrl,
+    serverFilesUrl: () => process.env.serverFilesUrl,
   },
 };
 </script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,13 +1,13 @@
 // change this to your own server.
 const serverBaseUrl = 'https://back-end.contentacms.io';
-const serverImagesUrl = 'https://back-end.contentacms.io';
+const serverFilesUrl = 'https://back-end.contentacms.io';
 
 export default {
   plugins: ['~plugins/vue-lazyload'],
   env: {
     serverBaseUrl,
     serverApiUrl: serverBaseUrl + '/api',
-    serverImagesUrl,
+    serverFilesUrl,
   },
   head: {
     meta: [

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,11 +1,13 @@
 // change this to your own server.
 const serverBaseUrl = 'https://back-end.contentacms.io';
+const serverImagesUrl = 'https://back-end.contentacms.io';
 
 export default {
   plugins: ['~plugins/vue-lazyload'],
   env: {
     serverBaseUrl,
     serverApiUrl: serverBaseUrl + '/api',
+    serverImagesUrl,
   },
   head: {
     meta: [


### PR DESCRIPTION
On a setup using ContentaCMS + ContentaJS, the api and images base urls can be different.
For example on a[ Docker setup with ddev](https://github.com/Mogtofu33/contenta-ddev) we use different hostnames for ContentaCMS and ContentaJS, which seems to be a realistic use case.

This PR simply add a _serverImagesUrl_ option to let the code load images from a different backend.
